### PR TITLE
[LO-2080] add count failed auth call

### DIFF
--- a/config/metricConfigs/learnMetrics.ts
+++ b/config/metricConfigs/learnMetrics.ts
@@ -142,6 +142,30 @@ const allowedMetrics: MetricsConfig = [
       }
     ],
     protocol: "statsd"
+  },
+  {
+    name: "count_failed_auth_call",
+    help: "Count the number of failed authentication calls",
+    type: "counter",
+    labels: [
+      {
+        name: "appName",
+        allowedValues: ["campus-app"]
+      },
+      {
+        name: "status_code",
+        allowedValues: ["none", "200", "400", "403", "404", "500", "502", "503", "504", "untracked"]
+      },
+      {
+        name: "timeout",
+        allowedValues: ["true", "false"]
+      },
+      {
+        name: "attempt",
+        allowedValues: ["1", "2"]
+      },
+    ],
+    protocol: "statsd"
   }
 ];
 


### PR DESCRIPTION
Adds a new metric to be send to prometheus.
[Send here from campus-app](https://github.com/datacamp-engineering/campus-app/blob/5b9ad097c8dff315a065f15d5d93f00c4abca662/src/redux/middlewares/boot/getUserAsPromise.ts#L42)