### PR TITLE
feat: allow workspace metric

### DIFF
--- a/config/metricConfigs/index.ts
+++ b/config/metricConfigs/index.ts
@@ -1,4 +1,5 @@
 import learnMetrics from './learnMetrics';
 import skillAssessmentMetrics from './skillAssessmentMetrics';
+import workspaceMetrics from './workspaceMetrics'
 
-export default [...learnMetrics, ...skillAssessmentMetrics];
+export default [...learnMetrics, ...skillAssessmentMetrics, ...workspaceMetrics];

--- a/config/metricConfigs/workspaceMetrics.ts
+++ b/config/metricConfigs/workspaceMetrics.ts
@@ -1,0 +1,18 @@
+import { MetricsConfig } from '../../src/aggregators/util';
+
+const allowedMetrics: MetricsConfig = [
+  {
+    name: "workspace_time_to_session_loaded",
+    help: "measures the time between session started and editor loaded",
+    type: "histogram",
+    labels: [
+      {
+        name: "editor",
+        allowedValues: ["JupyterLab", "RStudio"]
+      }
+    ],
+    protocol: "statsd"
+  },
+];
+
+export default allowedMetrics;


### PR DESCRIPTION
Allow the `workspace_time_to_session_loaded` metric from the workspace frontend.

https://github.com/datacamp-engineering/collab-and-tooling/pull/740/files#diff-1e3497e7949ec4adfac3482c555b5b93be9e72aace8877514d098ca8c475c1c2R131-R138