### PR TITLE
Consolidate Learn hub events into one

### DIFF
--- a/config/metricConfigs/learnMetrics.ts
+++ b/config/metricConfigs/learnMetrics.ts
@@ -168,9 +168,9 @@ const allowedMetrics: MetricsConfig = [
     protocol: "statsd"
   },
   {
-    name: "learn_hub__time_to_initial_dashboard_load_threshold",
-    help: "Count the number of page loads under the threshold",
-    type: "counter",
+    name: "learn_hub__time_to_initial_dashboard_load",
+    help: "Measure the time to interactive on the learn hub dashboard",
+    type: "histogram",
     labels: [
       {
         name: "appName",
@@ -183,22 +183,6 @@ const allowedMetrics: MetricsConfig = [
       {
         name: "underThreshold",
         allowedValues: ["true", "false"]
-      },
-    ],
-    protocol: "statsd"
-  },
-  {
-    name: "learn_hub__time_to_initial_dashboard_load",
-    help: "Measure the time to interactive on the learn hub dashboard",
-    type: "histogram",
-    labels: [
-      {
-        name: "appName",
-        allowedValues: ["/learn"]
-      },
-      {
-        name: "pageName",
-        allowedValues: ["dashboard"]
       },
     ],
     protocol: "statsd"

--- a/config/metricConfigs/learnMetrics.ts
+++ b/config/metricConfigs/learnMetrics.ts
@@ -169,7 +169,7 @@ const allowedMetrics: MetricsConfig = [
   },
   {
     name: "learn_hub__time_to_initial_dashboard_load",
-    help: "Measure the time to interactive on the learn hub dashboard",
+    help: "Measure the time to initial data load on the learn hub dashboard",
     type: "histogram",
     labels: [
       {


### PR DESCRIPTION
Turns out we don't need the `count` event to be sent separately. We can just count the logs in the query. 
Slack ref: https://datacamp.slack.com/archives/C02GEEJ5KQD/p1638960322002500