### PR TITLE
[CT-5656] add is notebook running label

### DIFF
--- a/config/metricConfigs/workspaceMetrics.ts
+++ b/config/metricConfigs/workspaceMetrics.ts
@@ -114,6 +114,10 @@ const allowedMetrics: MetricsConfig = [
         allowedValues: ["true", "false"]
       },
       {
+        name: "isNotebookRunning",
+        allowedValues: ["true", "false"]
+      },
+      {
         name: "language",
         allowedValues: ["R", "Python"]
       },
@@ -135,6 +139,10 @@ const allowedMetrics: MetricsConfig = [
       },
       {
         name: "isPremium",
+        allowedValues: ["true", "false"]
+      },
+      {
+        name: "isNotebookRunning",
         allowedValues: ["true", "false"]
       },
       {


### PR DESCRIPTION
Related ticket: https://datacamp.atlassian.net/browse/CT-5656
Related PR: https://github.com/datacamp-engineering/collab-and-tooling/pull/2984

- add isNotebookRunning label